### PR TITLE
feat:anime individual pages

### DIFF
--- a/components/AdventureSection.js
+++ b/components/AdventureSection.js
@@ -1,0 +1,50 @@
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faChevronLeft, faChevronRight } from "@fortawesome/free-solid-svg-icons";
+import React, { useEffect, useState } from 'react'
+import MovieCard from './MovieCard';
+import { setGenre } from '../redux/genreSlice';
+import { useDispatch } from 'react-redux';
+import { useRouter } from 'next/router';
+import Link from 'next/link';
+
+
+
+const AdventureSection = ({header,description,animeArray}) => {
+    const dispatch = useDispatch()
+    const router = useRouter()
+  return (
+    <div>
+    <div>
+         <section className="pl-6 pb-2 sm:pl-8 md:pl-10 xl:pl-6 lg:w-[80rem] lg:mx-auto ">
+          <main>
+              <div>
+              <h1 className="text-white text-2xl font-Poppins font-medium mb-2 sm:text-3xl sm:font-semibold ">{header}</h1>
+              <h2 className="text-white text-sm font-Poppins sm:text-base">{description}</h2>
+              <div className="bg-blue-400 w-auto max-w-[80rem] h-1 mt-3 mr-8 md:mr-20 lg:mr-72 xl:mr-0"/>
+              </div>
+        </main>
+        </section>
+        <section className="flex items-center mx-4  pb-20 xl:mx-20 gap-4">
+                <div className="hidden sm:w-10 sm:h-10 md:w-14 md:h-12 sm:flex items-center justify-center w-5 h-[35rem]  cursor-pointer ease-in-out duration-300 hover:bg-gray-800">
+                  <FontAwesomeIcon icon={faChevronLeft} className='text-sm sm:text-3xl text-white  font-extrabold '/>
+                </div>
+                    <div className="w-auto mt-8 flex items-center gap-0 overflow-hidden overflow-x-auto scrollbar-hide">
+                      {animeArray.map((anime,index) => {
+                        const posterImg = anime['posterImage']?.original
+                        return <div key={anime.id} onClick={() => dispatch(setGenre('adventure'))}>
+                                <Link href={`/${index}`}>
+                                  <MovieCard img={posterImg} title={anime?.canonicalTitle}/>
+                                  </Link>
+                              </div>
+                      })}
+                    </div>
+                <div className="hidden sm:w-10 sm:h-10 md:w-14 md:h-12 sm:flex items-center justify-center w-5 h-[35rem]  cursor-pointer ease-in-out duration-300  hover:bg-gray-800">
+                <FontAwesomeIcon icon={faChevronRight} className='text-sm  sm:text-3xl text-white font-extrabold'/>
+                </div>
+            </section>
+    </div>
+    </div>
+  )
+}
+
+export default AdventureSection

--- a/components/MusicSection.js
+++ b/components/MusicSection.js
@@ -2,13 +2,18 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faChevronLeft, faChevronRight } from "@fortawesome/free-solid-svg-icons";
 import React, { useEffect, useState } from 'react'
 import MovieCard from './MovieCard';
-import { useGetActionAnimeQuery, useGetAdventureAnimeQuery, useGetMusicAnimeQuery} from '../redux/services/animeApi';
+import { setGenre } from '../redux/genreSlice';
+import { useDispatch } from 'react-redux';
+import { useRouter } from 'next/router';
+import Link from 'next/link';
 
 
-const CardSection = ({header,description,animeArray}) => {
 
-
+const MusicSection = ({header,description,animeArray}) => {
+    const dispatch = useDispatch()
+    const router = useRouter()
   return (
+    <div>
     <div>
          <section className="pl-6 pb-2 sm:pl-8 md:pl-10 xl:pl-6 lg:w-[80rem] lg:mx-auto ">
           <main>
@@ -24,11 +29,13 @@ const CardSection = ({header,description,animeArray}) => {
                   <FontAwesomeIcon icon={faChevronLeft} className='text-sm sm:text-3xl text-white  font-extrabold '/>
                 </div>
                     <div className="w-auto mt-8 flex items-center gap-0 overflow-hidden overflow-x-auto scrollbar-hide">
-                      {animeArray.map((anime) => {
+                      {animeArray.map((anime,index) => {
                         const posterImg = anime['posterImage']?.original
-                        return <div key={anime.id}>
+                        return  <div key={anime.index} onClick={() => dispatch(setGenre('music'))}>
+                            <Link href={`/${index}`}>
                                   <MovieCard img={posterImg} title={anime?.canonicalTitle}/>
-                              </div>
+                            </Link>      
+                        </div>
                       })}
                     </div>
                 <div className="hidden sm:w-10 sm:h-10 md:w-14 md:h-12 sm:flex items-center justify-center w-5 h-[35rem]  cursor-pointer ease-in-out duration-300  hover:bg-gray-800">
@@ -36,7 +43,8 @@ const CardSection = ({header,description,animeArray}) => {
                 </div>
             </section>
     </div>
+    </div>
   )
 }
 
-export default CardSection
+export default MusicSection

--- a/components/MysterySection.js
+++ b/components/MysterySection.js
@@ -1,0 +1,50 @@
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faChevronLeft, faChevronRight } from "@fortawesome/free-solid-svg-icons";
+import React, { useEffect, useState } from 'react'
+import MovieCard from './MovieCard';
+import { setGenre } from '../redux/genreSlice';
+import { useDispatch } from 'react-redux';
+import { useRouter } from 'next/router';
+import Link from 'next/link';
+
+
+
+const MysterySection = ({header,description,animeArray}) => {
+    const dispatch = useDispatch()
+    const router = useRouter()
+  return (
+    <div>
+    <div>
+         <section className="pl-6 pb-2 sm:pl-8 md:pl-10 xl:pl-6 lg:w-[80rem] lg:mx-auto ">
+          <main>
+              <div>
+              <h1 className="text-white text-2xl font-Poppins font-medium mb-2 sm:text-3xl sm:font-semibold ">{header}</h1>
+              <h2 className="text-white text-sm font-Poppins sm:text-base">{description}</h2>
+              <div className="bg-blue-400 w-auto max-w-[80rem] h-1 mt-3 mr-8 md:mr-20 lg:mr-72 xl:mr-0"/>
+              </div>
+        </main>
+        </section>
+        <section className="flex items-center mx-4  pb-20 xl:mx-20 gap-4">
+                <div className="hidden sm:w-10 sm:h-10 md:w-14 md:h-12 sm:flex items-center justify-center w-5 h-[35rem]  cursor-pointer ease-in-out duration-300 hover:bg-gray-800">
+                  <FontAwesomeIcon icon={faChevronLeft} className='text-sm sm:text-3xl text-white  font-extrabold '/>
+                </div>
+                    <div className="w-auto mt-8 flex items-center gap-0 overflow-hidden overflow-x-auto scrollbar-hide">
+                      {animeArray.map((anime,index) => {
+                        const posterImg = anime['posterImage']?.original
+                        return <div key={anime.index} onClick={() => dispatch(setGenre('mystery'))}>
+                            <Link href={`/${index}`}>
+                                  <MovieCard img={posterImg} title={anime?.canonicalTitle}/>
+                            </Link>
+                        </div>
+                      })}
+                    </div>
+                <div className="hidden sm:w-10 sm:h-10 md:w-14 md:h-12 sm:flex items-center justify-center w-5 h-[35rem]  cursor-pointer ease-in-out duration-300  hover:bg-gray-800">
+                <FontAwesomeIcon icon={faChevronRight} className='text-sm  sm:text-3xl text-white font-extrabold'/>
+                </div>
+            </section>
+    </div>
+    </div>
+  )
+}
+
+export default MysterySection

--- a/components/Navbar.js
+++ b/components/Navbar.js
@@ -7,6 +7,7 @@ import { faBars, faCrown, faMagnifyingGlass, faUser, faCaretDown } from '@fortaw
 import { faBookmark } from '@fortawesome/free-regular-svg-icons'
 import { useState } from 'react'
 import DropdownItems from './DropdownItems'
+import Link from 'next/link'
 
 const Navbar = () => {
     const [showDrop,setShowDrop] = useState(false);
@@ -28,12 +29,16 @@ const Navbar = () => {
                     <FontAwesomeIcon icon={faBars} className='text-2xl'/>
                 </div>
                 <main>
-                    <div className='w-16 h-16 sm:hidden flex items-center justify-center cursor-pointer '>
-                        <Image src={YellowLogo} alt='Logo' objectFit='contain' />
-                    </div>
-                    <div className='w-48 h-16 pl-4 lg:pl-10 lg:w-56 hidden sm:flex items-center justify-center cursor-pointer '>
-                        <Image src={Big_Logo} alt='Logo' objectFit='contain' />
-                    </div>
+                    <Link href='/'>
+                        <div className='w-16 h-16 sm:hidden flex items-center justify-center cursor-pointer '>
+                            <Image src={YellowLogo} alt='Logo' objectFit='contain' />
+                        </div>
+                    </Link>
+                    <Link href='/'>
+                        <div className='w-48 h-16 pl-4 lg:pl-10 lg:w-56 hidden sm:flex items-center justify-center cursor-pointer '>
+                            <Image src={Big_Logo} alt='Logo' objectFit='contain' />
+                        </div>
+                    </Link>
                 </main>
                 <main className='flex  ml-4 '>
                     <div className={`w-28 h-16 lg:flex items-center justify-center gap-2 cursor-pointer ease-in-out duration-150 hover:bg-gray-900 ${showDrop && 'bg-gray-900'}

--- a/pages/[id].js
+++ b/pages/[id].js
@@ -1,0 +1,122 @@
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faStar, faCaretDown, faPlus} from '@fortawesome/free-solid-svg-icons';
+import { faBookmark } from '@fortawesome/free-regular-svg-icons';
+import Image from 'next/image';
+import { useRouter } from 'next/router';
+import React, { useEffect, useState } from 'react'
+import { useSelector } from 'react-redux';
+import Navbar from '../components/Navbar';
+import { useGetAdventureAnimeQuery, useGetMusicAnimeQuery, useGetMysteryAnimeQuery } from '../redux/services/animeApi';
+import { faPlayCircle } from '@fortawesome/free-regular-svg-icons';
+
+const SingleAnime = () => {
+    const router = useRouter()
+    const query = router.query;
+    console.log(query)
+    const fetchGenre = useSelector((state) => state.genre.newGenre)
+
+    const {data:adventureData,isSuccess} = useGetAdventureAnimeQuery();
+    const {data:musicData} = useGetMusicAnimeQuery()
+    const {data:mysteryData} = useGetMysteryAnimeQuery()
+    const [posterUrl,setPosterUrl] = useState('')
+    const [animeName,setAnimeName] = useState('')
+    const [rank,setRank] = useState(0)
+    const [description,setDescription] = useState('')
+    const [readmore,setReadmore] = useState(false);
+
+    const handleReadMore = () => {
+      readmore ? setReadmore(false) : setReadmore(true);
+    }
+
+
+
+  
+  
+    useEffect(() =>{
+  
+      if (isSuccess) {
+       if (fetchGenre == 'adventure') {
+        const animeDataImage = adventureData['data'][query.id]['attributes']['posterImage'].large;
+        setPosterUrl(animeDataImage);
+        const animeData = adventureData['data'][query.id]['attributes']
+        setAnimeName(animeData.canonicalTitle);
+        setRank(animeData.popularityRank)
+        setDescription(animeData.description)
+
+       }
+       if (fetchGenre == 'music') {
+        const animeDataImage = musicData['data'][query.id]['attributes']['posterImage'].large;
+        setPosterUrl(animeDataImage);
+        const animeData = musicData['data'][query.id]['attributes']
+        setAnimeName(animeData.canonicalTitle);
+        setRank(animeData.popularityRank)
+        setDescription(animeData.description)
+        
+       }
+       if (fetchGenre == 'mystery') {
+        const animeDataImage = mysteryData['data'][query.id]['attributes']['posterImage'].large;
+        setPosterUrl(animeDataImage);
+        const animeData = mysteryData['data'][query.id]['attributes']
+        setAnimeName(animeData.canonicalTitle);
+        setRank(animeData.popularityRank)
+        setDescription(animeData.description)
+       }
+
+      }
+  
+    },[adventureData,musicData,mysteryData])
+
+  return (
+    <div>
+      <section>
+        <Navbar/>
+        <div className='flex justify-center items-center w-screen relative top-12 bottom-0 h-[30rem]'>
+          <img src={posterUrl} className='w-[20rem] absolute z-10' alt={`${animeName} + 'Poster Image'`}/>
+          <img src={posterUrl} className='w-screen h-[22rem] absolute blur-2xl' alt={`${animeName} + 'Blurred Background'`}/>
+        </div>
+        <div className='bg-black h-auto mt-[2.2rem]'> 
+          <main className='mx-4'>
+              <div className='pt-6'>
+                <h1 className='text-white text-2xl mb-2'>{animeName}</h1>
+                <p className='text-gray-400'>217videos * Sub | Dub</p>
+                <div className='flex items-center gap-2 mt-4'>
+                  <FontAwesomeIcon icon={faStar} className='text-gray-300 text-2xl'/>
+                  <FontAwesomeIcon icon={faStar} className='text-gray-300 text-2xl'/>
+                  <FontAwesomeIcon icon={faStar} className='text-gray-300 text-2xl'/>
+                  <FontAwesomeIcon icon={faStar} className='text-gray-300 text-2xl'/>
+                  <FontAwesomeIcon icon={faStar} className='text-gray-300 text-2xl'/>
+                </div>
+                <section className='flex items-center mt-3'>
+                  <div className='flex items-center gap-2'>
+                    <p className='text-gray-300 text-sm'>Average Rating: <span className='text-white'>4.8(27.8K)</span></p>
+                    <FontAwesomeIcon icon={faCaretDown} className='text-white'/>
+                  </div>
+                  <hr className='rotate-90 w-4'/>
+                  <p className='text-gray-300 text-sm'>{rank.toLocaleString()} Reviews</p>
+                </section>
+              </div>
+              <section className='mt-6 flex items-center gap-4'>
+                    <button className='w-[18rem] h-[2.5rem] flex items-center justify-center gap-4 bg-orange-400'>
+                      <FontAwesomeIcon icon={faPlayCircle} className='text-lg'/>
+                      <h1 className='text-base font-medium'>START WATCHING S1 E1</h1>
+                    </button>
+                    <div className='w-[2.4rem] h-[2.5rem] flex items-center justify-center border-2 border-orange-400'>
+                      <FontAwesomeIcon icon={faBookmark} className='text-xl text-orange-400'/>
+                    </div>
+              </section>
+              <section className='flex items-center gap-3 mt-4 ml-2'>
+                <FontAwesomeIcon icon={faPlus} className='text-gray-300 text-2xl'/>
+                <p className='text-gray-300 text-base'>ADD TO CRUNCHYLIST</p>
+              </section>
+              <section className='mt-6'>
+                <p className={`text-white ${readmore ? 'line-clamp-6' : ''}`}>{description} </p>
+                <p className='text-gray-400 pb-4' onClick={handleReadMore}>Read More</p>
+              </section>
+            </main>
+         </div>
+      </section>
+    </div>
+  )
+}
+
+export default SingleAnime

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -6,9 +6,7 @@ import { animeApi } from '../redux/services/animeApi'
 
 function MyApp({ Component, pageProps }) {
   return <Provider store={store}>
-            <ApiProvider api={animeApi}>
               <Component {...pageProps} />
-            </ApiProvider>
           </Provider>
 
 }

--- a/pages/index.js
+++ b/pages/index.js
@@ -6,10 +6,12 @@ import SpyLarge from '../Assets/img/Spy-Large.webp'
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faChevronLeft, faChevronRight } from "@fortawesome/free-solid-svg-icons";
 import { useEffect, useState } from "react";
-import CardSection from "../components/CardSection";
 import { useGetActionAnimeQuery, useGetAdventureAnimeQuery, useGetMusicAnimeQuery, useGetMysteryAnimeQuery } from "../redux/services/animeApi";
 import StartWatching from "../components/StartWatching";
 import Footer from "../components/Footer";
+import AdventureSection from "../components/AdventureSection";
+import MusicSection from "../components/MusicSection";
+import MysterySection from "../components/MysterySection";
 // import { setInterval } from "timers/promises";
 
 export default function Home() {
@@ -90,14 +92,14 @@ export default function Home() {
           <div className="w-14 h-[0.25rem] cursor-pointer hover:h-[0.4rem] bg-white ease-in-out duration-50"/>
       </section>
       <section className="lg:mt-20">
-        <CardSection header='Free-to-Watch Anime!' animeArray={newAdventureArr} description='Watch some of our most popular titles right here!'/>
-        <CardSection header={`I'm Gonna Be a Star!`} animeArray={newMusicArr} description='These idols are determined to take over the musical world!'/>
+        <AdventureSection header='Free-to-Watch Anime!' animeArray={newAdventureArr} description='Watch some of our most popular titles right here!'/>
+        <MusicSection header={`I'm Gonna Be a Star!`} animeArray={newMusicArr} description='These idols are determined to take over the musical world!'/>
       </section>
       <section>
         <StartWatching/>
       </section>
       <section className="mt-6 ">
-        <CardSection header='Most Popular' animeArray={newMysteryArr}  />
+        <MysterySection header='Most Popular' animeArray={newMysteryArr}/>
       </section>
       <footer className="mt-6 md:mt-14 ">
         <Footer/>

--- a/redux/genreSlice.js
+++ b/redux/genreSlice.js
@@ -1,0 +1,23 @@
+import { createSlice, configureStore } from '@reduxjs/toolkit'
+
+
+const genreSlice = createSlice({
+    name: 'genre',
+    initialState: {
+      newGenre:''
+    },
+    reducers: {
+      setGenre: (state,action) => {
+        state.newGenre = action.payload
+        console.log("Payload",action.payload);
+      },
+   
+    
+    }
+  })
+
+export const { setGenre } = genreSlice.actions
+export default genreSlice.reducer
+
+
+  

--- a/store.js
+++ b/store.js
@@ -1,12 +1,14 @@
 import { configureStore } from '@reduxjs/toolkit'
 // Or from '@reduxjs/toolkit/query/react'
 import { setupListeners } from '@reduxjs/toolkit/query'
+import genreReducer from './redux/genreSlice'
 import { animeApi } from './redux/services/animeApi'
 
 export const store = configureStore({
   reducer: {
     // Add the generated reducer as a specific top-level slice
     [animeApi.reducerPath]: animeApi.reducer,
+    genre:genreReducer,
   },
   // Adding the api middleware enables caching, invalidation, polling,
   // and other useful features of `rtk-query`.


### PR DESCRIPTION
### **Anime Single Pages**:

- Implementation of anime individual pages for the homepage.

### **What has changed**:

- Deleted the CardSection component.
- Created seperate animeSection components based on genre which are as follows AdventureSection, MusicSection and MysterySection. This was done in order to get fetch the data of that specific genre when item is clicked.
- Created a genreSlice to toggle the genre when item is being clicked.
- Created a [id].js page which handles the individual pages.

### **What reviewers should know**:

- The components created are not fully responsive. Only mobile view has been implemented.
- Build was successful.
 